### PR TITLE
fix(logger): route Winston output to stderr for stdio transport

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -31,7 +31,7 @@ export class Logger {
       level,
       format: logFormat,
       transports: [
-        new winston.transports.Console(),
+        new winston.transports.Console({ stderrLevels: ['error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly'] }),
       ],
     });
   }


### PR DESCRIPTION
## Summary

This PR fixes #3 by configuring Winston's Console transport to route
every log level to stderr, keeping stdout exclusively for JSON-RPC
protocol messages as required by the MCP stdio transport.

## Problem

When running `bookstack-mcp-server` under Claude Desktop (or any
other stdio-based MCP client), the server disconnects immediately
with:

> MCP bookstack: Unexpected non-whitespace character after JSON at
> position 4 (line 1 column 5)

Root cause diagnosed by @skempken in #3: Winston's default Console
transport writes `info`, `warn`, and `debug` levels to stdout. MCP
stdio clients consume stdout exclusively as a JSON-RPC message
stream, so the very first log line — the "Configuration loaded"
message — corrupts the parser. The `2026` timestamp prefix starts
parsing as a JSON number, then breaks on the `-` at position 4.

The upstream MCP documentation is explicit about this constraint:

> Local MCP servers should not log messages to stdout (standard
> out), as this will interfere with protocol operation.
> — https://modelcontextprotocol.io/docs/tools/debugging

## Fix

Pass `stderrLevels` to the Console transport constructor, listing
every Winston severity level. This tells Winston to route all log
output to stderr regardless of level, leaving stdout clean for
JSON-RPC.

```diff
-        new winston.transports.Console(),
+        new winston.transports.Console({
+          stderrLevels: ['error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly'],
+        }),
```

This is the "proper fix" proposed by @skempken in #3. The
`LOG_LEVEL=error` workaround they mentioned also works but is a
compensating control rather than a root-cause fix — any future
log call at error level would re-introduce the same problem.

## Verification

Tested end-to-end against a real BookStack instance:

1. Applied the patch to `src/utils/logger.ts`
2. `npm install && npm run build` — clean build, no TypeScript errors
3. Ran the server manually with `MCP_TRANSPORT=stdio` and real
   BookStack credentials, redirecting stderr to a file
4. Confirmed terminal (stdout) stayed clean — no timestamped log
   lines, no "Configuration loaded" message, no "listening on
   stdio" message
5. Confirmed stderr log file captured all startup messages at the
   correct severity levels
6. Configured Claude Desktop to launch the patched build via
   `node dist/server.js`
7. Restarted Claude Desktop — no JSON parse error, MCP connector
   loaded cleanly
8. Called `bookstack_books_list` from a new Claude Desktop
   conversation — tool executed, returned real data from the
   BookStack API

## Scope

This PR addresses only the Winston stdout pollution (issue #3).
It does not touch #5 (HTTP mode connectivity), which appears to
be a separate issue with the Express transport routing and needs
its own investigation.

## Credits

Full credit to @skempken for diagnosing the root cause and
proposing the exact fix implemented here. This PR is the
implementation and verification of their analysis.