### PR TITLE
test(docker): assert the full page tool surface

### DIFF
--- a/tests/transport/docker-smoke.test.ts
+++ b/tests/transport/docker-smoke.test.ts
@@ -243,7 +243,7 @@ describe.skipIf(!SMOKE_ENABLED)('built image', () => {
       const payload = (await authenticated.json()) as {
         result?: { tools?: Array<{ name: string }> };
       };
-      expect(payload.result?.tools).toHaveLength(56);
+      expect(payload.result?.tools).toHaveLength(59);
     },
     STARTUP_TIMEOUT_MS + 15_000
   );


### PR DESCRIPTION
Fixes the CI-only stale tool-count assertion exposed after #22.

Validation:
- `bun run typecheck`
- `bunx biome check tests/transport/docker-smoke.test.ts`
- `docker build -t bookstack-mcp-server:ci .`
- `RUN_DOCKER_SMOKE=1 bun test tests/transport/docker-smoke.test.ts` (5 pass, 0 fail)